### PR TITLE
Fix the url for acquiring offline token

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -81,7 +81,7 @@ EOF
 If testing against the stage environment, generate an ingress auth token from your offline token:
 
 ```bash
-# Get your offline token from https://access.stage.redhat.com/management/api
+# Get your offline token from https://access.redhat.com/management/api
 # Then generate the ingress auth token:
 python scripts/ingress_token_from_offline_token.py --offline-token YOUR_OFFLINE_TOKEN --env stage
 export INGRESS_SERVER_AUTH_TOKEN="<use-the-token-from-above-command>"


### PR DESCRIPTION
Even for stage, the offline token needs to come from the prod sso.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated ONBOARDING.md to replace the offline token URL from https://access.stage.redhat.com/management/api to https://access.redhat.com/management/api in code snippets and guidance.
  - Clarifies the correct production endpoint for generating offline tokens, reducing confusion with staging URLs.
  - No functional changes to the product or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->