### PR TITLE
OLS-2114: Add licence to image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,6 +20,9 @@ WORKDIR /app-root
 COPY src ./src
 COPY pyproject.toml LICENSE README.md requirements.txt ./
 
+# this directory is checked by ecosystem-cert-preflight-checks task in Konflux
+COPY LICENSE /licenses/
+
 # Install dependencies
 RUN pip3.12 install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - None.
- Chores
  - Included the project LICENSE in the container image under /licenses to meet ecosystem certification checks and improve transparency for downstream consumers. This does not change runtime behavior or dependencies.
- Documentation
  - None.
- Refactor
  - None.
- Style
  - None.
- Tests
  - None.
- Revert
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->