### PR TITLE
Unpinning version for hatchling install.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,7 +21,7 @@ COPY src ./src
 COPY pyproject.toml LICENSE README.md requirements.*.txt ./
 
 # Install hermetic build dependency (no PIP_TARGET here to avoid conflict with Cachi2's --home)
-RUN pip3.12 install --no-cache-dir hatchling==1.29.0
+RUN pip3.12 install --no-cache-dir hatchling==1.30.0
 
 # Install runtime dependencies into a known location for copying to final image.
 # Unset Cachi2 pip options (e.g. PIP_INSTALL_OPTIONS=--home) to avoid "Cannot set --home and --prefix together"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -21,7 +21,7 @@ hatch-fancy-pypi-readme==25.1.0
     # via pydantic
 hatch-vcs==0.5.0
     # via urllib3
-hatchling==1.29.0
+hatchling==1.30.0
     # via
     #   annotated-types
     #   hatch-fancy-pypi-readme


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the pinned build tool (hatchling) from 1.29.0 to 1.30.0 in build configuration.
  * No runtime behavior or public APIs were changed; this is a build-time dependency update only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->