### PR TITLE
Make `ensure_size_limit()` run on upload failure

### DIFF
--- a/src/data_exporter.py
+++ b/src/data_exporter.py
@@ -98,18 +98,15 @@ class DataCollectorService:
         data_chunks = self.file_handler.gather_data_chunks(collected_files)
 
         if data_chunks:
-            self._handle_upload_batch(data_chunks, collected_files)
+            self._handle_upload_batch(data_chunks)
         else:
             logger.info("No data marked for collection in '%s'", self.data_dir)
 
-    def _handle_upload_batch(
-        self, data_chunks: list[list[Path]], collected_files: list[tuple[Path, int]]
-    ) -> None:
+    def _handle_upload_batch(self, data_chunks: list[list[Path]]) -> None:
         """Handle uploading a batch of data chunks.
 
         Args:
             data_chunks: List of data chunks to upload
-            collected_files: Original collected files for cleanup
         """
         try:
             for i, data_chunk in enumerate(data_chunks):
@@ -117,7 +114,7 @@ class DataCollectorService:
                 self._upload_single_chunk(data_chunk)
         finally:
             if self.cleanup_after_send:
-                self.file_handler.ensure_size_limit(collected_files)
+                self.file_handler.ensure_size_limit()
 
     def _upload_single_chunk(self, data_chunk: list[Path]) -> None:
         """Upload a single data chunk.

--- a/src/data_exporter.py
+++ b/src/data_exporter.py
@@ -111,13 +111,13 @@ class DataCollectorService:
             data_chunks: List of data chunks to upload
             collected_files: Original collected files for cleanup
         """
-        for i, data_chunk in enumerate(data_chunks):
-            logger.info("Uploading data chunk %d/%d", i + 1, len(data_chunks))
-            self._upload_single_chunk(data_chunk)
-
-        # Perform final cleanup after all chunks are uploaded
-        if self.cleanup_after_send:
-            self.file_handler.ensure_size_limit(collected_files)
+        try:
+            for i, data_chunk in enumerate(data_chunks):
+                logger.info("Uploading data chunk %d/%d", i + 1, len(data_chunks))
+                self._upload_single_chunk(data_chunk)
+        finally:
+            if self.cleanup_after_send:
+                self.file_handler.ensure_size_limit(collected_files)
 
     def _upload_single_chunk(self, data_chunk: list[Path]) -> None:
         """Upload a single data chunk.

--- a/src/file_handler.py
+++ b/src/file_handler.py
@@ -257,7 +257,7 @@ class FileHandler:
         """
         delete_files(file_paths, root_dir=self.data_dir)
 
-    def ensure_size_limit(self, collected_files: list[tuple[Path, int]]) -> None:
+    def ensure_size_limit(self) -> None:
         """Safeguard to prevent data directory overflow when export/cleanup fails.
 
         This method acts as a safety mechanism to prevent unbounded data accumulation
@@ -272,10 +272,8 @@ class FileHandler:
         order until the size limit is satisfied, preventing disk space exhaustion.
 
         The data are removed without any order or particular pattern
-
-        Args:
-            collected_files: List of tuples containing (file_path, file_size_bytes).
         """
+        collected_files = self.collect_files()
         data_size = sum(file_size for _, file_size in collected_files)
         if data_size > self.max_data_dir_size:
             logger.error(

--- a/tests/test_data_exporter.py
+++ b/tests/test_data_exporter.py
@@ -270,7 +270,7 @@ class TestDataCollectorServiceRun:
             mock_gather.assert_called_with(mock_files)
             mock_package.assert_called()
             mock_delete.assert_called_with([Path("/test/file1.json")])
-            mock_ensure.assert_called_with(mock_files)
+            mock_ensure.assert_called_with()
 
     @patch("src.file_handler.FileHandler.collect_files")
     @patch("src.file_handler.FileHandler.gather_data_chunks")
@@ -442,5 +442,5 @@ class TestDataCollectorServiceRun:
                 with pytest.raises(requests.RequestException):
                     service.run()
 
-        mock_ensure.assert_called_with(mock_files)
+        mock_ensure.assert_called_once_with()
         mock_delete.assert_not_called()

--- a/tests/test_data_exporter.py
+++ b/tests/test_data_exporter.py
@@ -6,6 +6,7 @@ import threading
 import time
 from unittest.mock import patch
 import io
+import pytest
 import requests
 import tarfile
 
@@ -405,3 +406,41 @@ class TestDataCollectorServiceRun:
                 mock_logger.info.assert_any_call(
                     "Retrying data collection in %d seconds...", custom_retry_interval
                 )
+
+    @patch("src.file_handler.FileHandler.collect_files")
+    @patch("src.file_handler.FileHandler.gather_data_chunks")
+    @patch("src.data_exporter.package_files_into_tarball")
+    @patch("src.file_handler.FileHandler.delete_collected_files")
+    @patch("src.file_handler.FileHandler.ensure_size_limit")
+    def test_ensure_size_limit_called_on_upload_failure(
+        self,
+        mock_ensure,
+        mock_delete,
+        mock_package,
+        mock_gather,
+        mock_collect,
+    ):
+        """Test ensure_size_limit is called when ingress returns non-202 status."""
+        mock_files = [(Path("/test/file1.json"), 100)]
+        mock_collect.return_value = mock_files
+        mock_gather.return_value = [[Path("/test/file1.json")]]
+        mock_package.return_value = io.BytesIO(b"tarball data")
+
+        mock_response = requests.Response()
+        mock_response.status_code = 500
+        mock_response._content = b'{"error": "internal server error"}'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = create_test_config(data_dir=Path(tmpdir), collection_interval=0)
+            service = DataCollectorService(config)
+
+            with patch.object(
+                service.ingress_client,
+                "_upload_data_to_ingress",
+                return_value=mock_response,
+            ):
+                with pytest.raises(requests.RequestException):
+                    service.run()
+
+        mock_ensure.assert_called_with(mock_files)
+        mock_delete.assert_not_called()

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -717,34 +717,43 @@ class TestFileHandler:
         # Root directory should remain
         assert temp_data_dir.exists()
 
+    @patch("src.file_handler.FileHandler.collect_files")
     @patch("src.file_handler.delete_files")
-    def test_ensure_size_limit_under_limit(self, mock_delete_files, handler, caplog):
+    def test_ensure_size_limit_under_limit(
+        self, mock_delete_files, mock_collect_files, handler, caplog
+    ):
         """Test ensure_size_limit when under the limit."""
         # Create handler with large limit
         handler.max_data_dir_size = 1000
 
-        collected_files = [(Path("file1.json"), 100), (Path("file2.json"), 200)]
+        mock_collect_files.return_value = [
+            (Path("file1.json"), 100),
+            (Path("file2.json"), 200),
+        ]
 
         with caplog.at_level(logging.ERROR):
-            handler.ensure_size_limit(collected_files)
+            handler.ensure_size_limit()
 
         # Should not delete anything or log errors
         mock_delete_files.assert_not_called()
         assert "Data folder size is bigger" not in caplog.text
 
+    @patch("src.file_handler.FileHandler.collect_files")
     @patch("src.file_handler.delete_files")
-    def test_ensure_size_limit_over_limit(self, mock_delete_files, handler, caplog):
+    def test_ensure_size_limit_over_limit(
+        self, mock_delete_files, mock_collect_files, handler, caplog
+    ):
         """Test ensure_size_limit when over the limit."""
         # Create handler with small limit
         handler.max_data_dir_size = 100
 
-        collected_files = [
+        mock_collect_files.return_value = [
             (Path("file1.json"), 80),
             (Path("file2.json"), 60),  # Total: 140 > 100
         ]
 
         with caplog.at_level(logging.INFO):
-            handler.ensure_size_limit(collected_files)
+            handler.ensure_size_limit()
 
         # Should delete the first file (80 bytes removed, bringing total to 60 < 100)
         mock_delete_files.assert_called_once_with(
@@ -756,21 +765,22 @@ class TestFileHandler:
         )
         assert "Removing files to fit the data into the limit" in caplog.text
 
+    @patch("src.file_handler.FileHandler.collect_files")
     @patch("src.file_handler.delete_files")
     def test_ensure_size_limit_multiple_deletions(
-        self, mock_delete_files, handler, caplog
+        self, mock_delete_files, mock_collect_files, handler, caplog
     ):
         """Test ensure_size_limit when multiple files need deletion."""
         handler.max_data_dir_size = 50
 
-        collected_files = [
+        mock_collect_files.return_value = [
             (Path("file1.json"), 40),
             (Path("file2.json"), 30),
             (Path("file3.json"), 20),  # Total: 90 > 50
         ]
 
         with caplog.at_level(logging.INFO):
-            handler.ensure_size_limit(collected_files)
+            handler.ensure_size_limit()
 
         # Should delete first two files (70 bytes removed, bringing total to 20 < 50)
         expected_calls = [


### PR DESCRIPTION
The upload path has two cleanup mechanisms with distinct roles:

- `delete_collected_files()`: deletes files that were successfully uploaded, called per-chunk after each successful upload.
- `ensure_size_limit()`: a safety net to prevent disk exhaustion, meant to cap the data directory size regardless of upload outcome.

Previously, `ensure_size_limit()` was only called after all chunks uploaded successfully at which point it was largely redundant, since `delete_collected_files()` had already removed the uploaded files. The actual scenario where `ensure_size_limit()` matters is when uploads fail (network errors, auth failures, endpoint unavailability) and files accumulate with no cleanup. But that was exactly the path where **it was never invoked when an exception was raised** during data upload, allowing unbounded data growth risking disk exhaustion:

https://github.com/lightspeed-core/lightspeed-to-dataverse-exporter/blob/eeeef9e824630379c659d2ff99343d7b70450ce2/src/ingress_client.py#L97-L99

Wrap the upload loop in `_handle_upload_batch()` with `try/finally` so `ensure_size_limit()` runs regardless of upload outcome.

Introduce a new `enforce_size_limit` config option (default: `True`), separate from `cleanup_after_send`, so that we have separate config option for cleanup when no more space in the data dir is left.

> [!WARNING] 
> This changes the behavior of the cleanup mechanism. From a code perspective it was a bug `ensure_size_limit()` was never used in the intended way: 
> https://github.com/lightspeed-core/lightspeed-to-dataverse-exporter/blob/eeeef9e824630379c659d2ff99343d7b70450ce2/src/file_handler.py#L260-L278
> However, from the user's perspective this PR introduces a new behavior.  By default, the Dataverse exporter will now delete data when the directory size limit is exceeded (e.g. when network issues prevent uploads)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File size limits are now enforced even when an upload fails.
  * Cleanup behavior is more reliable after data uploads, preventing unnecessary file deletion during failed transfers.

* **Tests**
  * Added coverage for upload failures and cleanup behavior.
  * Updated file-size limit tests to reflect the improved cleanup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->